### PR TITLE
Add Data.Strict.Classes with Strict class

### DIFF
--- a/strict/src/Data/Strict.hs
+++ b/strict/src/Data/Strict.hs
@@ -14,11 +14,13 @@
 -----------------------------------------------------------------------------
 
 module Data.Strict (
-    module Data.Strict.Tuple
+    module Data.Strict.Classes
+  , module Data.Strict.Tuple
   , module Data.Strict.Maybe
   , module Data.Strict.Either
 ) where
 
-import Data.Strict.Tuple hiding (toStrict, toLazy)
-import Data.Strict.Maybe hiding (toStrict, toLazy)
-import Data.Strict.Either hiding (toStrict, toLazy)
+import Data.Strict.Classes
+import Data.Strict.Tuple
+import Data.Strict.Maybe
+import Data.Strict.Either

--- a/strict/src/Data/Strict/Classes.hs
+++ b/strict/src/Data/Strict/Classes.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FunctionalDependencies #-}
+module Data.Strict.Classes (
+    Strict (..),
+) where
+
+import Prelude (return, (.))
+import qualified Prelude as L
+
+import Data.Strict.Tuple
+import Data.Strict.Maybe
+import Data.Strict.Either
+
+import qualified Control.Monad.ST.Lazy as L
+import qualified Control.Monad.ST.Strict as S
+import qualified Control.Monad.Trans.RWS.Lazy as L
+import qualified Control.Monad.Trans.RWS.Strict as S
+import qualified Control.Monad.Trans.State.Lazy as L
+import qualified Control.Monad.Trans.State.Strict as S
+import qualified Control.Monad.Trans.Writer.Lazy as L
+import qualified Control.Monad.Trans.Writer.Strict as S
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as LT
+
+-- | Ad hoc conversion between "strict" and "lazy" versions of a structure.
+--
+-- Unfortunately all externally defined instances are doomed to
+-- be orphans: https://gitlab.haskell.org/ghc/ghc/-/issues/11999
+-- See also https://qfpl.io/posts/orphans-and-fundeps/index.html for
+--
+class Strict lazy strict | lazy -> strict, strict -> lazy where
+  toStrict :: lazy -> strict
+  toLazy   :: strict -> lazy
+
+instance Strict (L.Maybe a) (Maybe a) where
+  toStrict L.Nothing  = Nothing
+  toStrict (L.Just x) = Just x
+  
+  toLazy Nothing  = L.Nothing
+  toLazy (Just x) = L.Just x
+
+instance Strict (a, b) (Pair a b) where
+  toStrict (a, b) = a :!: b
+  toLazy (a :!: b) = (a, b)
+
+instance Strict (L.Either a b) (Either a b) where
+  toStrict (L.Left x)  = Left x
+  toStrict (L.Right y) = Right y
+  
+  toLazy (Left x)  = L.Left x
+  toLazy (Right y) = L.Right y
+
+instance Strict LBS.ByteString BS.ByteString where
+#if MIN_VERSION_bytestring(0,10,0)
+  toStrict = LBS.toStrict
+  toLazy   = LBS.fromStrict
+#else
+  toStrict = BS.concat . LBS.toChunks
+  toLazy   = LBS.fromChunks . return {- singleton -}
+#endif
+
+instance Strict LT.Text T.Text where
+  toStrict = LT.toStrict
+  toLazy   = LT.fromStrict
+
+instance Strict (L.ST s a) (S.ST s a) where
+  toStrict = L.lazyToStrictST
+  toLazy   = L.strictToLazyST
+
+instance Strict (L.RWST r w s m a) (S.RWST r w s m a) where
+  toStrict = S.RWST . L.runRWST
+  toLazy   = L.RWST . S.runRWST
+
+instance Strict (L.StateT s m a) (S.StateT s m a) where
+  toStrict = S.StateT . L.runStateT
+  toLazy   = L.StateT . S.runStateT
+
+instance Strict (L.WriterT w m a) (S.WriterT w m a) where
+  toStrict = S.WriterT . L.runWriterT
+  toLazy   = L.WriterT . S.runWriterT

--- a/strict/src/Data/Strict/Either.hs
+++ b/strict/src/Data/Strict/Either.hs
@@ -1,7 +1,6 @@
-#if __GLASGOW_HASKELL__ >= 608
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE StandaloneDeriving #-}
-#endif
 #if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE DeriveGeneric      #-}
 #endif
@@ -28,7 +27,6 @@
 
 module Data.Strict.Either (
     Either(..)
-  , toStrict, toLazy
   , either
   , isLeft, isRight
   , fromLeft, fromRight

--- a/strict/src/Data/Strict/Maybe.hs
+++ b/strict/src/Data/Strict/Maybe.hs
@@ -1,7 +1,6 @@
-#if __GLASGOW_HASKELL__ >= 608
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE StandaloneDeriving #-}
-#endif
 #if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE DeriveGeneric      #-}
 #endif
@@ -34,7 +33,6 @@
 
 module Data.Strict.Maybe (
     Maybe(..)
-  , toStrict, toLazy
   , isJust
   , isNothing
   , fromJust

--- a/strict/src/Data/Strict/Tuple.hs
+++ b/strict/src/Data/Strict/Tuple.hs
@@ -1,7 +1,6 @@
-#if __GLASGOW_HASKELL__ >= 608
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE StandaloneDeriving #-}
-#endif
 #if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE DeriveGeneric      #-}
 #endif
@@ -31,7 +30,6 @@
 
 module Data.Strict.Tuple (
     Pair(..)
-  , toStrict, toLazy
 #ifndef __HADDOCK__
 #ifdef __GLASGOW_HASKELL__
   , (:!:)

--- a/strict/strict.cabal
+++ b/strict/strict.cabal
@@ -66,16 +66,21 @@ tested-with:
    || ==8.10.1
 
 library
-  default-language:   Haskell2010
-  hs-source-dirs:     src
-  ghc-options:        -Wall
-  default-extensions: CPP
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  ghc-options:      -Wall
+  other-extensions:
+    CPP
+    FunctionalDependencies
 
   build-depends:
-      base       >= 4.5.0.0 && < 5
-    , binary     >= 0.5.1.0 && < 0.9
-    , deepseq    >= 1.3.0.0 && < 1.5
-    , hashable   >= 1.2.7.0 && < 1.4
+      base         >= 4.5.0.0 && < 5
+    , binary       >= 0.5.1.0 && < 0.9
+    , bytestring   >= 0.9.2.1 && < 0.11
+    , deepseq      >= 1.3.0.0 && < 1.5
+    , hashable     >= 1.2.7.0 && < 1.4
+    , text         >= 1.2.3.0 && < 1.3
+    , transformers >= 0.3.0.0 && < 0.6
     , ghc-prim
 
   if !impl(ghc >= 8.0)
@@ -87,8 +92,9 @@ library
       bifunctors >= 5.5.2 && < 5.6
 
   exposed-modules:
+        Data.Strict
+        Data.Strict.Classes
         Data.Strict.Tuple
         Data.Strict.Maybe
         Data.Strict.Either
-        Data.Strict
         System.IO.Strict


### PR DESCRIPTION
The new `Strict` classes mirrors the `Strict` class in `lens`, but doesn't need lensy framework. Thus we can have it here and overload `toStrict` and `toLazy`.

I duplicated the definitions to avoid orphan instances, sadly they are unavoidable externally.

Question is: should we provide instances for `text`, `bytestring`  and `transformers`? (See https://hackage.haskell.org/package/lens-4.19.2/docs/Control-Lens-Iso.html#t:Strict). I think we could, as those dependencies are "free" i.e. bundled with GHC.