### PR TITLE
Add instances for assoc type-classes: Swap and Assoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -160,6 +160,10 @@ script:
   # Building without installed constraints for packages in global-db...
   - rm -f cabal.project.local
   - ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks all
+  # Constraint sets
+  - rm -rf cabal.project.local
+  # Constraint set no-assoc
+  - ${CABAL} v2-build $WITHCOMPILER --disable-tests --disable-benchmarks --constraint='strict -assoc' all
 
 # REGENDATA ("0.10.1",["--config=cabal.haskell-ci","cabal.project"])
 # EOF

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,1 +1,5 @@
 branches: master
+
+-- test that we build fine with assoc flag disabled
+constraint-set no-assoc
+  constraints: strict -assoc

--- a/strict/src/Data/Strict/Classes.hs
+++ b/strict/src/Data/Strict/Classes.hs
@@ -4,7 +4,7 @@ module Data.Strict.Classes (
     Strict (..),
 ) where
 
-import Prelude (return, (.))
+import Prelude ((.))
 import qualified Prelude as L
 
 import Data.Strict.Tuple
@@ -58,7 +58,7 @@ instance Strict LBS.ByteString BS.ByteString where
   toLazy   = LBS.fromStrict
 #else
   toStrict = BS.concat . LBS.toChunks
-  toLazy   = LBS.fromChunks . return {- singleton -}
+  toLazy   = LBS.fromChunks . L.return {- singleton -}
 #endif
 
 instance Strict LT.Text T.Text where

--- a/strict/src/Data/Strict/Either.hs
+++ b/strict/src/Data/Strict/Either.hs
@@ -58,6 +58,10 @@ import           GHC.Generics        (Generic (..))
 #endif
 import           Data.Hashable       (Hashable(..))
 
+#ifdef MIN_VERSION_assoc
+import           Data.Bifunctor.Assoc (Assoc (..))
+import           Data.Bifunctor.Swap  (Swap (..))
+#endif
 
 -- | The strict choice type.
 data Either a b = Left !a | Right !b deriving(Eq, Ord, Read, Show)
@@ -179,3 +183,19 @@ instance Bitraversable Either where
 -- hashable
 instance (Hashable a, Hashable b) => Hashable (Either a b) where
   hashWithSalt salt = hashWithSalt salt . toLazy
+
+-- assoc
+#ifdef MIN_VERSION_assoc
+instance Assoc Either where
+    assoc (Left (Left a))  = Left a
+    assoc (Left (Right b)) = Right (Left b)
+    assoc (Right c)        = Right (Right c)
+
+    unassoc (Left a)          = Left (Left a)
+    unassoc (Right (Left b))  = Left (Right b)
+    unassoc (Right (Right c)) = Right c
+
+instance Swap Either where
+    swap (Left x) = Right x
+    swap (Right x) = Left x
+#endif

--- a/strict/src/Data/Strict/Tuple.hs
+++ b/strict/src/Data/Strict/Tuple.hs
@@ -39,7 +39,7 @@ module Data.Strict.Tuple (
   , snd
   , curry
   , uncurry
-  , swap
+  , Data.Strict.Tuple.swap -- disambiguate
   , zip
   , unzip
 ) where
@@ -69,6 +69,11 @@ import           GHC.Generics        (Generic (..))
 #endif
 import           Data.Hashable       (Hashable(..))
 import           Data.Semigroup      (Semigroup (..))
+
+#ifdef MIN_VERSION_assoc
+import           Data.Bifunctor.Assoc (Assoc (..))
+import           Data.Bifunctor.Swap  (Swap (..))
+#endif
 
 #if __HADDOCK__
 import Data.Tuple ()
@@ -182,3 +187,13 @@ instance Bitraversable Pair where
 -- hashable
 instance (Hashable a, Hashable b) => Hashable (Pair a b) where
   hashWithSalt salt = hashWithSalt salt . toLazy
+
+-- assoc
+#ifdef MIN_VERSION_assoc
+instance Assoc Pair where
+    assoc ((a :!: b) :!: c) = (a :!: (b :!: c))
+    unassoc (a :!: (b :!: c)) = ((a :!: b) :!: c)
+
+instance Swap Pair where
+    swap = Data.Strict.Tuple.swap
+#endif

--- a/strict/strict.cabal
+++ b/strict/strict.cabal
@@ -66,6 +66,11 @@ tested-with:
    || ==8.8.3
    || ==8.10.1
 
+flag assoc
+  description: Build with assoc dependency
+  manual:      True
+  default:     True
+
 library
   default-language: Haskell2010
   hs-source-dirs:   src
@@ -91,6 +96,9 @@ library
   if !impl(ghc >= 8.2)
     build-depends:
       bifunctors >= 5.5.2 && < 5.6
+
+  if flag(assoc)
+    build-depends: assoc >= 1.0.1 && < 1.1
 
   exposed-modules:
         Data.Strict


### PR DESCRIPTION
The flag `assoc` allows to turn the dependency off,
making the dependency footprint small