### PR TITLE
Rearrange imports for less CPP

### DIFF
--- a/strict/src/Data/Strict/Either.hs
+++ b/strict/src/Data/Strict/Either.hs
@@ -35,7 +35,14 @@ module Data.Strict.Either (
   , partitionEithers
 ) where
 
-import           Prelude             hiding (Either (..), either)
+-- import parts explicitly, helps with compatibility
+import           Prelude (Functor (..), Eq, Ord, Show, Read, Bool (..), (.), error)
+import           Control.Applicative (pure, (<$>))
+import           Data.Semigroup (Semigroup (..))
+import           Data.Foldable (Foldable (..))
+import           Data.Traversable (Traversable (..))
+
+-- Lazy variants
 import qualified Prelude             as L
 
 import           Control.DeepSeq     (NFData (..))
@@ -43,21 +50,17 @@ import           Data.Bifoldable     (Bifoldable (..))
 import           Data.Bifunctor      (Bifunctor (..))
 import           Data.Binary         (Binary (..))
 import           Data.Bitraversable  (Bitraversable (..))
+import           Data.Hashable       (Hashable(..))
+
 #if MIN_VERSION_base(4,7,0)
 import           Data.Data           (Data (..), Typeable)
 #else
 import           Data.Data           (Data (..), Typeable2 (..))
 #endif
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative (pure, (<$>))
-import           Data.Foldable       (Foldable (..))
-import           Data.Traversable    (Traversable (..))
-import           Data.Monoid         (Monoid (..))
-#endif
+
 #if __GLASGOW_HASKELL__ >= 706
 import           GHC.Generics        (Generic (..))
 #endif
-import           Data.Hashable       (Hashable(..))
 
 #ifdef MIN_VERSION_assoc
 import           Data.Bifunctor.Assoc (Assoc (..))
@@ -116,7 +119,7 @@ rights x = [a | Right a <- x]
 -- | Analogous to 'L.partitionEithers' in "Data.Either".
 partitionEithers :: [Either a b] -> ([a],[b])
 partitionEithers =
-    Prelude.foldr (either left right) ([],[])
+    L.foldr (either left right) ([],[])
   where
     left  a ~(l, r) = (a:l, r)
     right a ~(l, r) = (l, a:r)
@@ -151,6 +154,10 @@ instance Foldable (Either e) where
 instance Traversable (Either e) where
   traverse _ (Left x)  = pure (Left x)
   traverse f (Right x) = Right <$> f x
+
+instance Semigroup (Either a b) where
+  Left _ <> b = b
+  a      <> _ = a
 
 -- deepseq
 instance (NFData a, NFData b) => NFData (Either a b) where

--- a/strict/src/Data/Strict/Maybe.hs
+++ b/strict/src/Data/Strict/Maybe.hs
@@ -45,29 +45,30 @@ module Data.Strict.Maybe (
   , mapMaybe
 ) where
 
-import           Prelude             hiding (Maybe (..), maybe)
+-- import parts explicitly, helps with compatibility
+import           Prelude (Functor (..), Eq, Ord, Show, Read, Bool (..), (.), error)
+import           Control.Applicative (pure, (<$>))
+import           Data.Monoid (Monoid (..))
+import           Data.Semigroup (Semigroup (..))
+import           Data.Foldable (Foldable (..))
+import           Data.Traversable (Traversable (..))
+
+-- Lazy variants
 import qualified Prelude             as L
 
 import           Control.DeepSeq     (NFData (..))
 import           Data.Binary         (Binary (..))
+import           Data.Hashable       (Hashable(..))
+
 #if MIN_VERSION_base(4,7,0)
 import           Data.Data           (Data (..), Typeable)
 #else
 import           Data.Data           (Data (..), Typeable1 (..))
 #endif
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative (pure, (<$>))
-import           Data.Foldable       (Foldable (..))
-import           Data.Traversable    (Traversable (..))
-import           Data.Monoid         (Monoid (..))
-#endif
+
 #if __GLASGOW_HASKELL__ >= 706
 import           GHC.Generics        (Generic (..))
 #endif
-import           Data.Hashable       (Hashable(..))
-import           Data.Semigroup      (Semigroup)
-import qualified Data.Semigroup      as Semigroup
-
 
 -- | The type of strict optional values.
 data Maybe a = Nothing | Just !a deriving(Eq, Ord, Show, Read)
@@ -152,7 +153,7 @@ deriving instance Generic  (Maybe a)
 instance Semigroup a => Semigroup (Maybe a) where
   Nothing <> m       = m
   m       <> Nothing = m
-  Just x1 <> Just x2 = Just (x1 Semigroup.<> x2)
+  Just x1 <> Just x2 = Just (x1 <> x2)
 
 #if MIN_VERSION_base(4,11,0)
 instance Semigroup a => Monoid (Maybe a) where

--- a/strict/src/Data/Strict/Tuple.hs
+++ b/strict/src/Data/Strict/Tuple.hs
@@ -45,31 +45,33 @@ module Data.Strict.Tuple (
   , unzip
 ) where
 
-import           Prelude             hiding (curry, fst, snd, uncurry, unzip,
-                                      zip)
+-- import parts explicitly, helps with compatibility
+import           Prelude (Functor (..), Eq, Ord, Show, Read, (.), Bounded, map)
+import           Control.Applicative ((<$>), (<*>))
+import           Data.Monoid (Monoid (..))
+import           Data.Semigroup (Semigroup (..))
+import           Data.Foldable (Foldable (..))
+import           Data.Traversable (Traversable (..))
+
+-- Lazy variants
+import qualified Prelude             as L
 
 import           Control.DeepSeq     (NFData (..))
 import           Data.Bifoldable     (Bifoldable (..))
 import           Data.Bifunctor      (Bifunctor (..))
-import           Data.Bitraversable  (Bitraversable (..))
 import           Data.Binary         (Binary (..))
+import           Data.Bitraversable  (Bitraversable (..))
+import           Data.Hashable       (Hashable(..))
+import           Data.Ix             (Ix (..))
+
 #if MIN_VERSION_base(4,7,0)
 import           Data.Data           (Data (..), Typeable)
 #else
 import           Data.Data           (Data (..), Typeable2 (..))
 #endif
-import           Data.Ix             (Ix (..))
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative (Applicative ((<*>)), (<$>))
-import           Data.Foldable       (Foldable (..))
-import           Data.Traversable    (Traversable (..))
-import           Data.Monoid         (Monoid (..))
-#endif
 #if __GLASGOW_HASKELL__ >= 706
 import           GHC.Generics        (Generic (..))
 #endif
-import           Data.Hashable       (Hashable(..))
-import           Data.Semigroup      (Semigroup (..))
 
 #ifdef MIN_VERSION_assoc
 import           Data.Bifunctor.Assoc (Assoc (..))
@@ -120,7 +122,7 @@ swap (a :!: b) = b :!: a
 
 -- | Zip for strict pairs (defined with zipWith).
 zip :: [a] -> [b] -> [Pair a b]
-zip x y = zipWith (:!:) x y
+zip x y = L.zipWith (:!:) x y
 
 -- | Unzip for stict pairs into a (lazy) pair of lists.
 unzip :: [Pair a b] -> ([a], [b])


### PR DESCRIPTION
This seems weird at first, but being explicit is more elegant than `hiding` + CPPd imports.