### PR TITLE
Use deriving clause for generics and typeable

### DIFF
--- a/strict/src/Data/Strict/Either.hs
+++ b/strict/src/Data/Strict/Either.hs
@@ -1,10 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE StandaloneDeriving #-}
-#if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE DeriveGeneric      #-}
-#endif
 
 #if MIN_VERSION_base(4,9,0)
 #define LIFTED_FUNCTOR_CLASSES 1
@@ -65,15 +62,11 @@ import           Data.Binary         (Binary (..))
 import           Data.Bitraversable  (Bitraversable (..))
 import           Data.Hashable       (Hashable(..))
 import           Data.Hashable.Lifted (Hashable1 (..), Hashable2 (..))
-
-#if MIN_VERSION_base(4,7,0)
+import           GHC.Generics        (Generic)
 import           Data.Data           (Data (..), Typeable)
-#else
-import           Data.Data           (Data (..), Typeable2 (..))
-#endif
 
 #if __GLASGOW_HASKELL__ >= 706
-import           GHC.Generics        (Generic, Generic1)
+import           GHC.Generics        (Generic1)
 #endif
 
 #if MIN_VERSION_deepseq(1,4,3)
@@ -94,7 +87,12 @@ import Data.Functor.Classes (Eq1 (..), Ord1 (..), Read1 (..), Show1 (..))
 #endif
 
 -- | The strict choice type.
-data Either a b = Left !a | Right !b deriving(Eq, Ord, Read, Show)
+data Either a b = Left !a | Right !b
+  deriving (Eq, Ord, Read, Show, Typeable, Data, Generic
+#if __GLASGOW_HASKELL__ >= 706
+    , Generic1
+#endif
+    )
 
 toStrict :: L.Either a b -> Either a b
 toStrict (L.Left x)  = Left x
@@ -152,20 +150,6 @@ partitionEithers =
 
 -- Instances
 ------------
-
-#if __GLASGOW_HASKELL__ >= 608
-deriving instance (Data a, Data b) => Data (Either a b)
-#endif
-#if MIN_VERSION_base(4,7,0)
-deriving instance Typeable Either
-#else
-deriving instance Typeable2 Either
-#endif
-
-#if __GLASGOW_HASKELL__ >= 706
-deriving instance Generic  (Either a b)
-deriving instance Generic1 (Either a)
-#endif
 
 instance Functor (Either a) where
   fmap _ (Left  x) = Left x

--- a/strict/src/Data/Strict/Maybe.hs
+++ b/strict/src/Data/Strict/Maybe.hs
@@ -1,10 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE StandaloneDeriving #-}
-#if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE DeriveGeneric      #-}
-#endif
 
 #if MIN_VERSION_base(4,9,0)
 #define LIFTED_FUNCTOR_CLASSES 1
@@ -73,15 +70,12 @@ import           Control.DeepSeq     (NFData (..))
 import           Data.Binary         (Binary (..))
 import           Data.Hashable       (Hashable(..))
 import           Data.Hashable.Lifted (Hashable1 (..))
-
-#if MIN_VERSION_base(4,7,0)
+import           GHC.Generics        (Generic)
 import           Data.Data           (Data (..), Typeable)
-#else
-import           Data.Data           (Data (..), Typeable1 (..))
-#endif
+
 
 #if __GLASGOW_HASKELL__ >= 706
-import           GHC.Generics        (Generic, Generic1)
+import           GHC.Generics        (Generic1)
 #endif
 
 #if MIN_VERSION_deepseq(1,4,3)
@@ -95,7 +89,12 @@ import Data.Functor.Classes (Eq1 (..), Ord1 (..), Read1 (..), Show1 (..))
 #endif
 
 -- | The type of strict optional values.
-data Maybe a = Nothing | Just !a deriving(Eq, Ord, Show, Read)
+data Maybe a = Nothing | Just !a
+  deriving (Eq, Ord, Read, Show, Typeable, Data, Generic
+#if __GLASGOW_HASKELL__ >= 706
+    , Generic1
+#endif
+    )
 
 toStrict :: L.Maybe a -> Maybe a
 toStrict L.Nothing  = Nothing
@@ -160,20 +159,6 @@ mapMaybe f (x:xs) = case f x of
 
 -- Instances
 ------------
-
-#if __GLASGOW_HASKELL__ >= 608
-deriving instance Data a => Data (Maybe a)
-#endif
-#if MIN_VERSION_base(4,7,0)
-deriving instance Typeable Maybe
-#else
-deriving instance Typeable1 Maybe
-#endif
-
-#if __GLASGOW_HASKELL__ >= 706
-deriving instance Generic  (Maybe a)
-deriving instance Generic1 Maybe
-#endif
 
 instance Semigroup a => Semigroup (Maybe a) where
   Nothing <> m       = m

--- a/strict/src/Data/Strict/Tuple.hs
+++ b/strict/src/Data/Strict/Tuple.hs
@@ -1,10 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE Safe #-}
-{-# LANGUAGE StandaloneDeriving #-}
-#if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE DeriveGeneric      #-}
-#endif
 #ifndef __HADDOCK__
 #ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE TypeOperators      #-}
@@ -77,14 +74,11 @@ import           Data.Bitraversable  (Bitraversable (..))
 import           Data.Hashable       (Hashable(..))
 import           Data.Hashable.Lifted (Hashable1 (..), Hashable2 (..))
 import           Data.Ix             (Ix (..))
-
-#if MIN_VERSION_base(4,7,0)
+import           GHC.Generics        (Generic)
 import           Data.Data           (Data (..), Typeable)
-#else
-import           Data.Data           (Data (..), Typeable2 (..))
-#endif
+
 #if __GLASGOW_HASKELL__ >= 706
-import           GHC.Generics        (Generic, Generic1)
+import           GHC.Generics        (Generic1)
 #endif
 
 #if MIN_VERSION_deepseq(1,4,3)
@@ -115,7 +109,12 @@ import Data.Tuple ()
 infixl 2 :!:
 
 -- | The type of strict pairs.
-data Pair a b = !a :!: !b deriving (Eq, Ord, Show, Read, Bounded, Ix)
+data Pair a b = !a :!: !b
+  deriving (Eq, Ord, Read, Show, Typeable, Data, Generic, Bounded, Ix
+#if __GLASGOW_HASKELL__ >= 706
+    , Generic1
+#endif
+    )
 
 #ifndef __HADDOCK__
 #ifdef __GLASGOW_HASKELL__
@@ -162,21 +161,6 @@ unzip x = ( map fst x
 
 -- Instances
 ------------
-
-#if __GLASGOW_HASKELL__ >= 608
-deriving instance (Data a, Data b) => Data (Pair a b)
-#endif
-#if MIN_VERSION_base(4,7,0)
-deriving instance Typeable Pair
-#else
-deriving instance Typeable2 Pair
-#endif
-
--- fails with compiler panic on GHC 7.4.2
-#if __GLASGOW_HASKELL__ >= 706
-deriving instance Generic  (Pair a b)
-deriving instance Generic1 (Pair a)
-#endif
 
 instance Functor (Pair e) where
     fmap f = toStrict . fmap f . toLazy


### PR DESCRIPTION
This makes `Generic` instance available for GHC-7.4, and removes some CPP