### PR TITLE
Add strict-lens package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,8 +114,11 @@ install:
   - touch cabal.project
   - |
     echo "packages: strict" >> cabal.project
+    echo "packages: strict-lens" >> cabal.project
     echo "packages: strict-base-types" >> cabal.project
   - if [ $HCNUMVER -ge 80200 ] ; then echo 'package strict' >> cabal.project ; fi
+  - "if [ $HCNUMVER -ge 80200 ] ; then echo '  ghc-options: -Werror=missing-methods' >> cabal.project ; fi"
+  - if [ $HCNUMVER -ge 80200 ] ; then echo 'package strict-lens' >> cabal.project ; fi
   - "if [ $HCNUMVER -ge 80200 ] ; then echo '  ghc-options: -Werror=missing-methods' >> cabal.project ; fi"
   - if [ $HCNUMVER -ge 80200 ] ; then echo 'package strict-base-types' >> cabal.project ; fi
   - "if [ $HCNUMVER -ge 80200 ] ; then echo '  ghc-options: -Werror=missing-methods' >> cabal.project ; fi"
@@ -124,10 +127,11 @@ install:
     echo "  type:     git"                                        >> cabal.project
     echo "  location: https://github.com/phadej/qc-instances.git" >> cabal.project
     echo "  tag:      380204ba34b7844d594748a722e122958dde56c6"   >> cabal.project
-  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(strict|strict-base-types)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
+  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(strict|strict-base-types|strict-lens)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
   - if [ -f "strict/configure.ac" ]; then (cd "strict" && autoreconf -i); fi
+  - if [ -f "strict-lens/configure.ac" ]; then (cd "strict-lens" && autoreconf -i); fi
   - if [ -f "strict-base-types/configure.ac" ]; then (cd "strict-base-types" && autoreconf -i); fi
   - ${CABAL} v2-freeze $WITHCOMPILER ${TEST} ${BENCH}
   - "cat cabal.project.freeze | sed -E 's/^(constraints: *| *)//' | sed 's/any.//'"
@@ -144,14 +148,18 @@ script:
   - find . -maxdepth 1 -type f -name '*.tar.gz' -exec tar -xvf '{}' \;
   - find . -maxdepth 1 -type f -name '*.tar.gz' -exec rm       '{}' \;
   - PKGDIR_strict="$(find . -maxdepth 1 -type d -regex '.*/strict-[0-9.]*')"
+  - PKGDIR_strict_lens="$(find . -maxdepth 1 -type d -regex '.*/strict-lens-[0-9.]*')"
   - PKGDIR_strict_base_types="$(find . -maxdepth 1 -type d -regex '.*/strict-base-types-[0-9.]*')"
   # Generate cabal.project
   - rm -rf cabal.project cabal.project.local cabal.project.freeze
   - touch cabal.project
   - |
     echo "packages: ${PKGDIR_strict}" >> cabal.project
+    echo "packages: ${PKGDIR_strict_lens}" >> cabal.project
     echo "packages: ${PKGDIR_strict_base_types}" >> cabal.project
   - if [ $HCNUMVER -ge 80200 ] ; then echo 'package strict' >> cabal.project ; fi
+  - "if [ $HCNUMVER -ge 80200 ] ; then echo '  ghc-options: -Werror=missing-methods' >> cabal.project ; fi"
+  - if [ $HCNUMVER -ge 80200 ] ; then echo 'package strict-lens' >> cabal.project ; fi
   - "if [ $HCNUMVER -ge 80200 ] ; then echo '  ghc-options: -Werror=missing-methods' >> cabal.project ; fi"
   - if [ $HCNUMVER -ge 80200 ] ; then echo 'package strict-base-types' >> cabal.project ; fi
   - "if [ $HCNUMVER -ge 80200 ] ; then echo '  ghc-options: -Werror=missing-methods' >> cabal.project ; fi"
@@ -160,7 +168,7 @@ script:
     echo "  type:     git"                                        >> cabal.project
     echo "  location: https://github.com/phadej/qc-instances.git" >> cabal.project
     echo "  tag:      380204ba34b7844d594748a722e122958dde56c6"   >> cabal.project
-  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(strict|strict-base-types)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
+  - "for pkg in $($HCPKG list --simple-output); do echo $pkg | sed 's/-[^-]*$//' | (grep -vE -- '^(strict|strict-base-types|strict-lens)$' || true) | sed 's/^/constraints: /' | sed 's/$/ installed/' >> cabal.project.local; done"
   - cat cabal.project || true
   - cat cabal.project.local || true
   # Building...
@@ -171,6 +179,7 @@ script:
   - ${CABAL} v2-build $WITHCOMPILER ${TEST} ${BENCH} all
   # cabal check...
   - (cd ${PKGDIR_strict} && ${CABAL} -vnormal check)
+  - (cd ${PKGDIR_strict_lens} && ${CABAL} -vnormal check)
   - (cd ${PKGDIR_strict_base_types} && ${CABAL} -vnormal check)
   # haddock...
   - ${CABAL} v2-haddock $WITHCOMPILER --with-haddock $HADDOCK ${TEST} ${BENCH} all

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,5 @@
 packages: strict/
+packages: strict-lens/
 packages: strict-base-types/
 
 source-repository-package

--- a/strict-base-types/src/Data/Either/Strict.hs
+++ b/strict-base-types/src/Data/Either/Strict.hs
@@ -24,7 +24,7 @@
 --
 -----------------------------------------------------------------------------
 module Data.Either.Strict (
-    Either(Left, Right)
+    Either(..)
   , isRight
   , isLeft
   , either
@@ -36,15 +36,14 @@ module Data.Either.Strict (
 ) where
 
 import           Data.Strict.Classes (toStrict, toLazy)
-import           Data.Strict.Either  (Either (Left, Right), either, isLeft,
+import           Data.Strict.Either  (Either (..), either, isLeft,
                                       isRight, lefts, rights, partitionEithers)
 import           Prelude             hiding (Either (..), either)
-import qualified Prelude             as L
 
-import           Control.Lens.Iso    (Strict (..), Swapped (..), iso)
-import           Control.Lens.Prism  (Prism, prism)
 import           Data.Aeson          (FromJSON (..), ToJSON (..))
 
+
+import Data.Strict.Lens (_Left, _Right)
 import Test.QuickCheck.Instances.Strict ()
 
 -- missing instances
@@ -56,20 +55,3 @@ instance (ToJSON a, ToJSON b) => ToJSON (Either a b) where
 
 instance (FromJSON a, FromJSON b) => FromJSON (Either a b) where
   parseJSON val = fmap toStrict (parseJSON val)
-
--- lens
-instance Strict (L.Either a b) (Either a b) where
-  strict = iso toStrict toLazy
-
-instance Swapped Either where
-  swapped = either Right Left `iso` either Right Left
-
--- TODO: Each (Either a)
-
--- | Analogous to 'Control.Lens.Prism._Left' in "Control.Lens.Prism".
-_Left :: Prism (Either a c) (Either b c) a b
-_Left = prism Left $ either L.Right (L.Left . Right)
-
--- | Analogous to 'Control.Lens.Prism._Right' in "Control.Lens.Prism".
-_Right :: Prism (Either c a) (Either c b) a b
-_Right = prism Right $ either (L.Left . Left) L.Right

--- a/strict-base-types/src/Data/Maybe/Strict.hs
+++ b/strict-base-types/src/Data/Maybe/Strict.hs
@@ -31,7 +31,7 @@
 -----------------------------------------------------------------------------
 
 module Data.Maybe.Strict (
-     Maybe(Nothing,Just)
+     Maybe(..)
    , maybe
 
    , isJust
@@ -47,16 +47,14 @@ module Data.Maybe.Strict (
 ) where
 
 import           Data.Strict.Classes (toStrict, toLazy)
-import           Data.Strict.Maybe   (Maybe (Nothing, Just), fromJust,
+import           Data.Strict.Maybe   (Maybe (..), fromJust,
                                       fromMaybe, isJust, isNothing, maybe,
                                       listToMaybe, maybeToList, mapMaybe, catMaybes)
 import           Prelude             hiding (Maybe (..), maybe)
-import qualified Prelude             as L
 
-import           Control.Lens.Iso    (Strict (..), iso)
-import           Control.Lens.Prism  (Prism, Prism', prism, prism')
 import           Data.Aeson          (FromJSON (..), ToJSON (..))
 
+import Data.Strict.Lens (_Just, _Nothing)
 import Test.QuickCheck.Instances.Strict ()
 
 -- missing instances
@@ -68,17 +66,3 @@ instance ToJSON a => ToJSON (Maybe a) where
 
 instance FromJSON a => FromJSON (Maybe a) where
   parseJSON val = fmap toStrict (parseJSON val)
-
--- lens
-instance Strict (L.Maybe a) (Maybe a) where
-  strict = iso toStrict toLazy
-
--- TODO: Each Maybe
-
--- | Analogous to 'Control.Lens.Prism._Just' in "Control.Lens.Prism"
-_Just :: Prism (Maybe a) (Maybe b) a b
-_Just = prism Just $ maybe (Left Nothing) Right
-
--- | Analogous to 'Control.Lens.Prism._Nothing' in "Control.Lens.Prism"
-_Nothing :: Prism' (Maybe a) ()
-_Nothing = prism' (const Nothing) $ maybe (L.Just ()) (const L.Nothing)

--- a/strict-base-types/strict-base-types.cabal
+++ b/strict-base-types/strict-base-types.cabal
@@ -125,10 +125,9 @@ library
   ghc-options:    -Wall -fwarn-incomplete-uni-patterns
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
-  build-depends: strict >=0.4 && <0.4.1
+  build-depends: strict >=0.4 && <0.4.1, strict-lens >=0.4 && <0.5
   build-depends:
       base       >= 4.5     && < 5
-    , lens       >= 4.19.2  && < 4.20
     , aeson      >= 1.4.6.0 && < 1.6
     , quickcheck-instances >= 0.3.24 && <0.4
     , ghc-prim

--- a/strict-lens/CHANGES.md
+++ b/strict-lens/CHANGES.md
@@ -1,0 +1,3 @@
+## 0.4
+
+- Initial release, splitted of `strict-base-types`

--- a/strict-lens/LICENSE
+++ b/strict-lens/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) Roman Leshchinskiy 2006-2007
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the author nor the names of his contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/strict-lens/Setup.lhs
+++ b/strict-lens/Setup.lhs
@@ -1,0 +1,3 @@
+#!/usr/bin/env runhaskell
+> import Distribution.Simple
+> main = defaultMain

--- a/strict-lens/src/Data/Strict/Lens.hs
+++ b/strict-lens/src/Data/Strict/Lens.hs
@@ -1,0 +1,158 @@
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE DeriveDataTypeable    #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE UndecidableInstances  #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Data.Strict.Lens (
+    -- * Tuple
+    -- | See instances, in particular for 'Field1' and 'Field2' type classes.
+    -- * Either
+    _Left, _Right,
+    -- * Maybe
+    _Just, _Nothing,
+    -- * These
+    here, there,
+    _This, _That, _These,
+    ) where
+
+
+import           Control.Applicative (pure, (<$>), (<*>))
+import           Prelude             (Int, flip, ($), (.))
+
+-- Lazy variants
+import qualified Prelude             as L
+import qualified Control.Lens        as L
+
+import           Control.Lens        (Each (..), Field1 (..), Field2 (..),
+                                      Index, Prism, Prism', Swapped (..),
+                                      Traversal, indexed, iso, prism, prism',
+                                      (<&>))
+
+import           Data.Strict         (Either (..), Maybe (..), Pair (..),
+                                      Strict (..), These (..), either, maybe,
+                                      swap, these)
+
+-------------------------------------------------------------------------------
+-- Tuple
+-------------------------------------------------------------------------------
+
+instance L.Strict (a, b) (Pair a b) where
+  strict = iso toStrict toLazy
+
+instance Field1 (Pair a b) (Pair a' b) a a' where
+  _1 k (a :!: b) = indexed k (0 :: Int) a <&> \a' -> (a' :!: b)
+
+instance Field2 (Pair a b) (Pair a b') b b' where
+  _2 k (a :!: b) = indexed k (1 :: Int) b <&> \b' -> (a :!: b')
+
+instance Swapped Pair where
+  swapped = iso swap swap
+
+type instance Index (Pair a b) = Int
+instance (a~a', b~b') => Each (Pair a a') (Pair b b') a b where
+  each f ~(a :!: b) = (:!:) <$> f a <*> f b
+  {-# INLINE each #-}
+
+-------------------------------------------------------------------------------
+-- Either
+-------------------------------------------------------------------------------
+
+instance L.Strict (L.Either a b) (Either a b) where
+  strict = iso toStrict toLazy
+
+instance Swapped Either where
+  swapped = either Right Left `iso` either Right Left
+
+instance Each (Either c a) (Either c b) a b
+
+-- | Analogous to 'Control.Lens.Prism._Left' in "Control.Lens.Prism".
+_Left :: Prism (Either a c) (Either b c) a b
+_Left = prism Left $ either L.Right (L.Left . Right)
+
+-- | Analogous to 'Control.Lens.Prism._Right' in "Control.Lens.Prism".
+_Right :: Prism (Either c a) (Either c b) a b
+_Right = prism Right $ either (L.Left . Left) L.Right
+
+-------------------------------------------------------------------------------
+-- Maybe
+-------------------------------------------------------------------------------
+
+instance L.Strict (L.Maybe a) (Maybe a) where
+  strict = iso toStrict toLazy
+
+instance Each (Maybe a) (Maybe b) a b
+
+-- | Analogous to 'Control.Lens.Prism._Just' in "Control.Lens.Prism"
+_Just :: Prism (Maybe a) (Maybe b) a b
+_Just = prism Just $ maybe (L.Left Nothing) L.Right
+
+-- | Analogous to 'Control.Lens.Prism._Nothing' in "Control.Lens.Prism"
+_Nothing :: Prism' (Maybe a) ()
+_Nothing = prism' (L.const Nothing) $ maybe (L.Just ()) (L.const L.Nothing)
+
+-------------------------------------------------------------------------------
+-- These
+-------------------------------------------------------------------------------
+
+instance Swapped These where
+    swapped = iso swapThese swapThese
+
+instance Each (These c a) (These c b) a b
+
+-- | A 'Control.Lens.Traversal' of the first half of a 'These', suitable for use with "Control.Lens".
+--
+-- >>> over here show (That 1)
+-- That 1
+--
+-- >>> over here show (These 'a' 2)
+-- These "'a'" 2
+--
+here :: Traversal (These a c) (These b c) a b
+here f (This x)    = This <$> f x
+here f (These x y) = flip These y <$> f x
+here _ (That x)    = pure (That x)
+
+-- | A 'Control.Lens.Traversal' of the second half of a 'These', suitable for use with "Control.Lens".
+--
+-- @
+-- 'there' :: 'Control.Lens.Traversal' ('These' t b) ('These' t b) a b
+-- @
+--
+-- >>> over there show (That 1)
+-- That "1"
+--
+-- >>> over there show (These 'a' 2)
+-- These 'a' "2"
+--
+there :: Traversal (These c a) (These c b) a b
+there _ (This x)    = pure (This x)
+there f (These x y) = These x <$> f y
+there f (That x)    = That <$> f x
+
+-- | A 'Control.Lens.Prism'' selecting the 'This' constructor.
+--
+-- /Note:/ cannot change type.
+_This :: Prism' (These a b) a
+_This = prism This (these L.Right (L.Left . That) (\x y -> L.Left $ These x y))
+
+-- | A 'Control.Lens.Prism'' selecting the 'That' constructor.
+--
+-- /Note:/ cannot change type.
+_That :: Prism' (These a b) b
+_That = prism That (these (L.Left . This) L.Right (\x y -> L.Left $ These x y))
+
+-- | A 'Control.Lens.Prism'' selecting the 'These' constructor. 'These' names are ridiculous!
+--
+-- /Note:/ cannot change type.
+_These :: Prism' (These a b) (a, b)
+_These = prism (\(a,b) -> These a b) (these (L.Left . This) (L.Left . That) (\x y -> L.Right (x, y)))
+
+swapThese :: These a b -> These b a
+swapThese (This a)    = That a
+swapThese (That b)    = This b
+swapThese (These a b) = These b a

--- a/strict-lens/strict-lens.cabal
+++ b/strict-lens/strict-lens.cabal
@@ -1,0 +1,54 @@
+name:               strict-lens
+version:            0.4
+synopsis:           Lenses for types in strict package
+category:           Data, Lenses
+description:        Lenses for types in strict package.
+license:            BSD3
+license-file:       LICENSE
+author:
+  Roman Leshchinskiy <rl@cse.unsw.edu.au>,
+  Simon Meier <iridcode@gmail.com>
+
+maintainer:         Oleg Grenrus <oleg.grenrus@iki.fi>
+copyright:
+  (c) 2006-2008 by Roman Leshchinskiy
+  (c) 2013-2014 by Simon Meier
+
+homepage:           https://github.com/haskell-strict/strict
+cabal-version:      >=1.10
+build-type:         Simple
+tested-with:
+  GHC ==7.4.2
+   || ==7.6.3
+   || ==7.8.4
+   || ==7.10.3
+   || ==8.0.2
+   || ==8.2.2
+   || ==8.4.4
+   || ==8.6.5
+   || ==8.8.3
+   || ==8.10.1
+
+extra-source-files: CHANGES.md
+
+source-repository head
+  type:     git
+  location: https://github.com/haskell-strict/strict.git
+  subdir:   strict-lens
+
+library
+  default-language: Haskell2010
+  ghc-options:      -Wall -fwarn-incomplete-uni-patterns
+
+  if impl(ghc >=8.0)
+    ghc-options:
+      -Wcompat -Wnoncanonical-monad-instances
+      -Wnoncanonical-monadfail-instances
+
+  build-depends:
+      base    >=4.5    && <5
+    , lens    >=4.19.2 && <4.20
+    , strict  >=0.4    && <0.4.1
+
+  hs-source-dirs:   src
+  exposed-modules:  Data.Strict.Lens


### PR DESCRIPTION
It's becoming apparent that `aeson` instances is the only thing left in `strict-base-types`.