### PR TITLE
Adapt strict-base-types to aeson-1.5.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ install:
   - |
     echo "packages: strict" >> cabal.project
     echo "packages: strict-lens" >> cabal.project
-    echo "packages: strict-base-types" >> cabal.project
+    if [ $HCNUMVER -ge 70800 ] ; then echo "packages: strict-base-types" >> cabal.project ; fi
     if [ $HCNUMVER -ge 80000 ] ; then echo "packages: strict-optics" >> cabal.project ; fi
   - if [ $HCNUMVER -ge 80200 ] ; then echo 'package strict' >> cabal.project ; fi
   - "if [ $HCNUMVER -ge 80200 ] ; then echo '  ghc-options: -Werror=missing-methods' >> cabal.project ; fi"
@@ -155,7 +155,7 @@ script:
   - |
     echo "packages: ${PKGDIR_strict}" >> cabal.project
     echo "packages: ${PKGDIR_strict_lens}" >> cabal.project
-    echo "packages: ${PKGDIR_strict_base_types}" >> cabal.project
+    if [ $HCNUMVER -ge 70800 ] ; then echo "packages: ${PKGDIR_strict_base_types}" >> cabal.project ; fi
     if [ $HCNUMVER -ge 80000 ] ; then echo "packages: ${PKGDIR_strict_optics}" >> cabal.project ; fi
   - if [ $HCNUMVER -ge 80200 ] ; then echo 'package strict' >> cabal.project ; fi
   - "if [ $HCNUMVER -ge 80200 ] ; then echo '  ghc-options: -Werror=missing-methods' >> cabal.project ; fi"
@@ -178,7 +178,7 @@ script:
   # cabal check...
   - (cd ${PKGDIR_strict} && ${CABAL} -vnormal check)
   - (cd ${PKGDIR_strict_lens} && ${CABAL} -vnormal check)
-  - (cd ${PKGDIR_strict_base_types} && ${CABAL} -vnormal check)
+  - if [ $HCNUMVER -ge 70800 ] ; then (cd ${PKGDIR_strict_base_types} && ${CABAL} -vnormal check) ; fi
   - if [ $HCNUMVER -ge 80000 ] ; then (cd ${PKGDIR_strict_optics} && ${CABAL} -vnormal check) ; fi
   # haddock...
   - ${CABAL} v2-haddock $WITHCOMPILER --with-haddock $HADDOCK ${TEST} ${BENCH} all

--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,4 @@
 packages: strict/
 packages: strict-lens/
 packages: strict-base-types/
-
--- This requires GHC-8.0+
--- if testing older compilers, comment this out
 packages: strict-optics/

--- a/strict-base-types/src/Data/Either/Strict.hs
+++ b/strict-base-types/src/Data/Either/Strict.hs
@@ -35,23 +35,8 @@ module Data.Either.Strict (
   , _Right
 ) where
 
-import           Data.Strict.Classes (toStrict, toLazy)
-import           Data.Strict.Either  (Either (..), either, isLeft,
-                                      isRight, lefts, rights, partitionEithers)
-import           Prelude             hiding (Either (..), either)
-
-import           Data.Aeson          (FromJSON (..), ToJSON (..))
-
-
+import Data.Aeson ()
+import Data.Strict.Either  (Either (..), either, isLeft, isRight, lefts, rights, partitionEithers)
 import Data.Strict.Lens (_Left, _Right)
+import Prelude ()
 import Test.QuickCheck.Instances.Strict ()
-
--- missing instances
---------------------
-
--- aeson
-instance (ToJSON a, ToJSON b) => ToJSON (Either a b) where
-  toJSON = toJSON . toLazy
-
-instance (FromJSON a, FromJSON b) => FromJSON (Either a b) where
-  parseJSON val = fmap toStrict (parseJSON val)

--- a/strict-base-types/src/Data/Maybe/Strict.hs
+++ b/strict-base-types/src/Data/Maybe/Strict.hs
@@ -46,23 +46,8 @@ module Data.Maybe.Strict (
    , _Nothing
 ) where
 
-import           Data.Strict.Classes (toStrict, toLazy)
-import           Data.Strict.Maybe   (Maybe (..), fromJust,
-                                      fromMaybe, isJust, isNothing, maybe,
-                                      listToMaybe, maybeToList, mapMaybe, catMaybes)
-import           Prelude             hiding (Maybe (..), maybe)
-
-import           Data.Aeson          (FromJSON (..), ToJSON (..))
-
+import Data.Aeson ()
 import Data.Strict.Lens (_Just, _Nothing)
+import Data.Strict.Maybe   (Maybe (..), fromJust, fromMaybe, isJust, isNothing, maybe, listToMaybe, maybeToList, mapMaybe, catMaybes)
+import Prelude ()
 import Test.QuickCheck.Instances.Strict ()
-
--- missing instances
---------------------
-
--- aeson
-instance ToJSON a => ToJSON (Maybe a) where
-  toJSON = toJSON . toLazy
-
-instance FromJSON a => FromJSON (Maybe a) where
-  parseJSON val = fmap toStrict (parseJSON val)

--- a/strict-base-types/src/Data/Tuple/Strict.hs
+++ b/strict-base-types/src/Data/Tuple/Strict.hs
@@ -22,7 +22,6 @@
 --
 -----------------------------------------------------------------------------
 
-
 module Data.Tuple.Strict (
     Pair(..)
   , fst
@@ -34,30 +33,8 @@ module Data.Tuple.Strict (
   , unzip
 ) where
 
-import           Data.Strict.Classes (toStrict, toLazy)
-import           Data.Strict.Tuple   (Pair (..), curry, fst, snd, uncurry,
-                                      swap, unzip, zip)
-import           Prelude             hiding (curry, fst, snd, uncurry, unzip,
-                                      zip)
-
-import           Data.Aeson          (FromJSON (..), ToJSON (..))
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative ((<$>))
-#endif
-
-#if __HADDOCK__
-import Data.Tuple ()
-#endif
-
+import Data.Aeson ()
 import Data.Strict.Lens ()
+import Data.Strict.Tuple (Pair (..), curry, fst, snd, uncurry, swap, unzip, zip)
+import Prelude ()
 import Test.QuickCheck.Instances.Strict ()
-
--- missing instances
---------------------
-
--- aeson
-instance (ToJSON a, ToJSON b) => ToJSON (Pair a b) where
-  toJSON = toJSON . toLazy
-
-instance (FromJSON a, FromJSON b) => FromJSON (Pair a b) where
-  parseJSON val = toStrict <$> parseJSON val

--- a/strict-base-types/strict-base-types.cabal
+++ b/strict-base-types/strict-base-types.cabal
@@ -1,119 +1,39 @@
-Name:           strict-base-types
-Version:        0.7
-Synopsis:       Strict variants of the types provided in base.
-Category:       Data
-Description:
-     It is common knowledge that lazy datastructures can lead to space-leaks.
-     This problem is particularly prominent, when using lazy datastructures to
-     store the state of a long-running application in memory. The easiest
-     solution to this problem is to use fully strict types to store such state
-     values. By \"fully strict types\" we mean types for whose values it holds
-     that, if they are in weak-head normal form, then they are also in normal
-     form. Intuitively, this means that values of fully strict types cannot
-     contain unevaluated thunks.
-     .
-     To define a fully strict datatype, one typically uses the following recipe.
-     .
-     1. Make all fields of every constructor strict; i.e., add a bang to
-        all fields.
-     .
-     2. Use only strict types for the fields of the constructors.
-     .
-     The second requirement is problematic as it rules out the use of
-     the standard Haskell 'Maybe', 'Either', and pair types. This library
-     solves this problem by providing strict variants of these types and their
-     corresponding standard support functions and type-class instances.
-     .
-     Note that this library does currently not provide fully strict lists.
-     They can be added if they are really required. However, in many cases one
-     probably wants to use unboxed or strict boxed vectors from the 'vector'
-     library (<http://hackage.haskell.org/package/vector>) instead of strict
-     lists.  Moreover, instead of @String@s one probably wants to use strict
-     @Text@ values from the @text@ library
-     (<http://hackage.haskell.org/package/text>).
-     .
-     This library comes with batteries included; i.e., missing instances
-     for type-classes from the @deepseq@, @binary@, @aeson@, @QuickCheck@, and
-     @lens@ packages are included. Of particluar interest is the @Strict@
-     type-class provided by the lens library
-     (<http://hackage.haskell.org/packages/archive/lens/3.9.0.2/doc/html/Control-Lens-Iso.html#t:Strict>).
-     It is used in the following example to simplify the modification of
-     strict fields.
-     .
-     > (-# LANGUAGE TemplateHaskell #-)   -- replace with curly braces,
-     > (-# LANGUAGE OverloadedStrings #-) -- the Haddock prologues are a P.I.T.A!
-     >
-     > import           Control.Lens ( (.=), Strict(strict), from, Iso', makeLenses)
-     > import           Control.Monad.State.Strict (State)
-     > import qualified Data.Map                   as M
-     > import qualified Data.Maybe.Strict          as S
-     > import qualified Data.Text                  as T
-     >
-     > -- | An example of a state record as it could be used in a (very minimal)
-     > -- role-playing game.
-     > data GameState = GameState
-     >     ( _gsCooldown :: !(S.Maybe Int)
-     >     , _gsHealth   :: !Int
-     >     )  -- replace with curly braces, *grmbl*
-     >
-     > makeLenses ''GameState
-     >
-     > -- The isomorphism, which converts a strict field to its lazy variant
-     > lazy :: Strict lazy strict => Iso' strict lazy
-     > lazy = from strict
-     >
-     > type Game = State GameState
-     >
-     > cast :: T.Text -> Game ()
-     > cast spell =
-     >     gsCooldown.lazy .= M.lookup spell spellDuration
-     >     -- ... implement remainder of spell-casting ...
-     >   where
-     >     spellDuration = M.fromList [("fireball", 5)]
-     .
-     See
-     <http://www.haskellforall.com/2013/05/program-imperatively-using-haskell.html>
-     for a gentle introduction to lenses and state manipulation.
-     .
-     Note that this package uses the types provided by the 'strict' package
-     (<http://hackage.haskell.org/package/strict>), but organizes them a bit
-     differently. More precisely, the @strict-base-types@ package
-     .
-     - only provides the fully strict variants of types from 'base',
-     .
-     - is in-sync with the current base library (base-4.6),
-     .
-     - provides the missing instances for (future) Haskell platform packages, and
-     .
-     - conforms to the standard policy that strictness variants of an existing
-       datatype are identified by suffixing \'Strict\' or \'Lazy\' in the
-       module hierarchy.
+name:               strict-base-types
+version:            0.7
+synopsis:           Strict variants of the types provided in base.
+category:           Data
+description:
+  Since version 0.7 the functionality in this package
+  have been merged into `strict`, `aeson` and `quickcheck-instances`
+  packages, and lens functionality moved into `strict-lens` package.
 
+license:            BSD3
+license-file:       LICENSE
+author:
+  Roman Leshchinskiy <rl@cse.unsw.edu.au>,
+  Simon Meier <iridcode@gmail.com>
 
-License:        BSD3
-License-File:   LICENSE
-Author:         Roman Leshchinskiy <rl@cse.unsw.edu.au>,
-                Simon Meier <iridcode@gmail.com>
-Maintainer:     Bas van Dijk <v.dijk.bas@gmail.com>, Oleg Grenrus <oleg.grenrus@iki.fi>, Simon Meier <iridcode@gmail.com>
-Copyright:      (c) 2006-2008 by Roman Leshchinskiy
-                (c) 2013-2014 by Simon Meier
-Homepage:       https://github.com/haskell-strict/strict
-Cabal-Version: >= 1.10
-Build-type:     Simple
-Tested-with:
-  GHC==7.4.2,
-  GHC==7.6.3,
-  GHC==7.8.4,
-  GHC==7.10.3,
-  GHC==8.0.2,
-  GHC==8.2.2,
-  GHC==8.4.4,
-  GHC==8.6.5,
-  GHC==8.8.3,
-  GHC==8.10.1
+maintainer:
+  Bas van Dijk <v.dijk.bas@gmail.com>, Oleg Grenrus <oleg.grenrus@iki.fi>, Simon Meier <iridcode@gmail.com>
 
-extra-source-files:
-  CHANGES
+copyright:
+  (c) 2006-2008 by Roman Leshchinskiy
+  (c) 2013-2014 by Simon Meier
+
+homepage:           https://github.com/haskell-strict/strict
+cabal-version:      >=1.10
+build-type:         Simple
+tested-with:
+  GHC ==7.8.4
+   || ==7.10.3
+   || ==8.0.2
+   || ==8.2.2
+   || ==8.4.4
+   || ==8.6.5
+   || ==8.8.3
+   || ==8.10.1
+
+extra-source-files: CHANGES
 
 source-repository head
   type:     git
@@ -122,22 +42,16 @@ source-repository head
 
 library
   default-language: Haskell2010
-  ghc-options:    -Wall -fwarn-incomplete-uni-patterns
-  if impl(ghc >= 8.0)
-    ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
-  build-depends: strict >=0.4 && <0.4.1, strict-lens >=0.4 && <0.5
+  ghc-options:      -Wall
   build-depends:
-      base       >= 4.5     && < 5
-    , aeson      >= 1.4.6.0 && < 1.6
-    , quickcheck-instances >= 0.3.24 && <0.4
-    , ghc-prim
+      aeson                 >=1.5.3.0 && <1.6
+    , base                  >=4.7     && <5
+    , quickcheck-instances  >=0.3.24  && <0.4
+    , strict                >=0.4     && <0.4.1
+    , strict-lens           >=0.4     && <0.5
 
-  if !impl(ghc >= 8.0)
-    build-depends: semigroups >= 0.18.5 && <0.20
-
-  hs-source-dirs:    src
+  hs-source-dirs:   src
   exposed-modules:
-      Data.Tuple.Strict
-      Data.Maybe.Strict
-      Data.Either.Strict
-
+    Data.Either.Strict
+    Data.Maybe.Strict
+    Data.Tuple.Strict


### PR DESCRIPTION
This is speculative PR, depending on whether https://github.com/bos/aeson/pull/795 is merged.